### PR TITLE
Feat/adding bill metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,32 @@ Gauge type
 | os | Operating system (linux/macos/windows) |
 | repo | Repository like \<org>/\<repo> |
 | status | Runner status (online/offline) |
+
+### github_workflow_usage_seconds
+Gauge type
+(If you have private repositories that use GitHub-hosted runners)
+
+**Result possibility**
+
+| Gauge | Description |
+|---|---|
+| seconds | Number of billable seconds used by a specific workflow during the current billing cycle. |
+
+**Fields**
+
+| Name | Description |
+|---|---|
+| id | Workflow id (incremental id) |
+| node_id | Node ID (github actions) |
+| name | workflow name |
+| os | Operating system (linux/macos/windows) |
+| repo | Repository like \<org>/\<repo> |
+| status | Workflow status |
+
+Es:
+
+```
+# HELP github_workflow_usage Number of billable seconds used by a specific workflow during the current billing cycle. Any job re-runs are also included in the usage. Only apply to workflows in private repositories that use GitHub-hosted runners.
+# TYPE github_workflow_usage gauge
+github_workflow_usage_seconds{id="2862037",name="Create Release",node_id="MDg6V29ya2Zsb3cyODYyMDM3",repo="xxx/xxx",state="active",os="UBUNTU"} 706.609
+```

--- a/main.go
+++ b/main.go
@@ -38,6 +38,13 @@ var (
 		},
 		[]string{"repo", "id", "node_id", "head_branch", "head_sha", "run_number", "event", "status"},
 	)
+	workflowBillGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_workflow_usage",
+			Help: "job status",
+		},
+		[]string{"repo", "id", "node_id", "name", "state", "typeOS"},
+	)
 )
 
 type runners struct {
@@ -69,6 +76,39 @@ type job struct {
 	UpdatedAt  string `json:"updated_at"`
 }
 
+type workflowsReturn struct {
+	TotalCount int        `json:"total_count"`
+	Workflows  []workflow `json:"workflows"`
+}
+
+type workflow struct {
+	ID     int    `json:"id"`
+	NodeID string `json:"node_id"`
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	State  string `json:"state"`
+}
+
+type UBUNTU struct {
+	TotalMs float64 `json:"total_ms"`
+}
+type MACOS struct {
+	TotalMs float64 `json:"total_ms"`
+}
+type WINDOWS struct {
+	TotalMs float64 `json:"total_ms"`
+}
+
+type Bill struct {
+	Billable Billable `json:"billable"`
+}
+
+type Billable struct {
+	UBUNTU  UBUNTU  `json:"UBUNTU"`
+	MACOS   MACOS   `json:"MACOS"`
+	WINDOWS WINDOWS `json:"WINDOWS"`
+}
+
 // main init configuration
 func main() {
 	app := cli.NewApp()
@@ -84,6 +124,7 @@ func main() {
 func runWeb(ctx *cli.Context) {
 	go getRunnersFromGithub()
 	go getJobsFromGithub()
+	go getBillableFromGithub()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/metrics")
@@ -97,6 +138,7 @@ func runWeb(ctx *cli.Context) {
 func init() {
 	prometheus.MustRegister(runnersGauge)
 	prometheus.MustRegister(jobsGauge)
+	prometheus.MustRegister(workflowBillGauge)
 }
 
 func getRunnersFromGithub() {
@@ -161,5 +203,51 @@ func getJobsFromGithub() {
 		}
 
 		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)
+	}
+}
+
+func getBillableFromGithub() {
+	client := &http.Client{}
+	for {
+		for _, repo := range config.Github.Repositories {
+			var p workflowsReturn
+			req, _ := http.NewRequest("GET", "https://api.github.com/repos/"+repo+"/actions/workflows", nil)
+			req.Header.Set("Authorization", "token "+config.Github.Token)
+			resp, err := client.Do(req)
+			defer resp.Body.Close()
+			if err != nil {
+				log.Fatal(err)
+			}
+			if resp.StatusCode != 200 {
+				log.Fatalf("the status code returned by the server is different from 200: %d", resp.StatusCode)
+			}
+			err = json.NewDecoder(resp.Body).Decode(&p)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for _, w := range p.Workflows {
+				var bill Bill
+				req, _ := http.NewRequest("GET", "https://api.github.com/repos/"+repo+"/actions/workflows/"+strconv.Itoa(w.ID)+"/timing", nil)
+				req.Header.Set("Authorization", "token "+config.Github.Token)
+				resp2, err := client.Do(req)
+				defer resp2.Body.Close()
+				if err != nil {
+					log.Fatal(err)
+				}
+				if resp.StatusCode != 200 {
+					log.Fatalf("the status code returned by the server is different from 200: %d", resp.StatusCode)
+				}
+				err = json.NewDecoder(resp2.Body).Decode(&bill)
+				if err != nil {
+					log.Fatal(err)
+				}
+				workflowBillGauge.WithLabelValues(repo, strconv.Itoa(w.ID), w.NodeID, w.Name, w.State, "MACOS").Set(bill.Billable.MACOS.TotalMs / 1000)
+				workflowBillGauge.WithLabelValues(repo, strconv.Itoa(w.ID), w.NodeID, w.Name, w.State, "WINDOWS").Set(bill.Billable.WINDOWS.TotalMs / 1000)
+				workflowBillGauge.WithLabelValues(repo, strconv.Itoa(w.ID), w.NodeID, w.Name, w.State, "UBUNTU").Set(bill.Billable.UBUNTU.TotalMs / 1000)
+			}
+		}
+
+		time.Sleep(time.Duration(config.Github.Refresh) * 5 * time.Second)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -40,10 +40,10 @@ var (
 	)
 	workflowBillGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "github_workflow_usage",
+			Name: "github_workflow_usage_seconds",
 			Help: "Number of billable seconds used by a specific workflow during the current billing cycle. Any job re-runs are also included in the usage. Only apply to workflows in private repositories that use GitHub-hosted runners.",
 		},
-		[]string{"repo", "id", "node_id", "name", "state", "typeOS"},
+		[]string{"repo", "id", "node_id", "name", "state", "os"},
 	)
 )
 

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var (
 	workflowBillGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "github_workflow_usage",
-			Help: "job status",
+			Help: "Number of billable seconds used by a specific workflow during the current billing cycle. Any job re-runs are also included in the usage. Only apply to workflows in private repositories that use GitHub-hosted runners.",
 		},
 		[]string{"repo", "id", "node_id", "name", "state", "typeOS"},
 	)


### PR DESCRIPTION
Added new metrics `github_workflow_usage `:
```
# HELP github_workflow_usage Number of billable seconds used by a specific workflow during the current billing cycle. Any job re-runs are also included in the usage. Only apply to workflows in private repositories that use GitHub-hosted runners.
# TYPE github_workflow_usage gauge
github_workflow_usage_seconds{id="2862037",name="Create Release",node_id="MDg6V29ya2Zsb3cyODYyMDM3",repo="xxx/xxx",state="active",os="MACOS"} 0
github_workflow_usage_seconds{id="2862037",name="Create Release",node_id="MDg6V29ya2Zsb3cyODYyMDM3",repo="xxx/xxx",state="active",os="UBUNTU"} 706.609
github_workflow_usage_seconds{id="2862037",name="Create Release",node_id="MDg6V29ya2Zsb3cyODYyMDM3",repo="xxx/xxx",state="active",os="WINDOWS"} 7193.223
```