### PR TITLE
add ability to auth using github apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ If you want to monitor a public repository, you must put the public_repo option 
 | Name | Flag | Env vars | Default | Description |
 |---|---|---|---|---|
 | Github Token | github_token, gt | GITHUB_TOKEN | - | Personnal Access Token |
+| Github App Installation ID | github_app_installation_id, gaiid| GITHUB_APP_INSTALLATION_ID | - | Github App Installation ID |
+| Github App ID | github_app_id, gaid| GITHUB_APP_ID | - | Github App ID |
+| Github App Private Key | github_app_private_key, gapk | GITHUB_APP_PRIVATE_KEY | - | Private key, or path to file that contains the key |
 | Github Refresh | github_refresh, gr | GITHUB_REFRESH | 30 | Refresh time Github Actions status in sec |
 | Github Organizations | github_orgas, go | GITHUB_ORGAS | - | List all organizations you want get informations. Format \<orga1>,\<orga2>,\<orga3> (like test1,test2) |
 | Github Repos | github_repos, grs | GITHUB_REPOS | - | List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test) |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
+
+
+###### NOTE: Github App authentication will not be used if a github token is provided.
 
 ## Exported stats
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github-actions-exporter
 go 1.16
 
 require (
+	github.com/bradleyfalzon/ghinstallation v1.1.1 // indirect
 	github.com/fasthttp/router v1.3.9 // indirect
 	github.com/google/go-github/v33 v33.0.1-0.20210311004518-0540c33dca8b // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bradleyfalzon/ghinstallation v1.1.1 h1:pmBXkxgM1WeF8QYvDLT5kuQiHMcmf+X015GI0KM/E3I=
+github.com/bradleyfalzon/ghinstallation v1.1.1/go.mod h1:vyCmHTciHx/uuyN82Zc3rXN3X2KTK8nUTCrTMwAhcug=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -80,6 +82,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -151,6 +154,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
+github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-github/v33 v33.0.1-0.20210311004518-0540c33dca8b h1:EUf9qFA+oxcRcZVR3UlG4FM031+ZA8DQWHgedI7fnm8=
 github.com/google/go-github/v33 v33.0.1-0.20210311004518-0540c33dca8b/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,11 +5,14 @@ import "github.com/urfave/cli/v2"
 var (
 	// Github - github configuration
 	Github struct {
-		Token         string
-		Refresh       int64
-		Repositories  cli.StringSlice
-		Organizations cli.StringSlice
-		APIURL        string
+		Token             string
+		AppInstallationID int64
+		AppID             int64
+		AppPrivateKey     string
+		Refresh           int64
+		Repositories      cli.StringSlice
+		Organizations     cli.StringSlice
+		APIURL            string
 	}
 	// Port - http port used by fasthttp
 	Port int
@@ -34,6 +37,27 @@ func InitConfiguration() []cli.Flag {
 			EnvVars:     []string{"GITHUB_TOKEN"},
 			Usage:       "Github Personal Token",
 			Destination: &Github.Token,
+		},
+		&cli.Int64Flag{
+			Name:        "github_app_installation_id",
+			Aliases:     []string{"gaiid"},
+			EnvVars:     []string{"GITHUB_APP_INSTALLATION_ID"},
+			Usage:       "Github App Installation ID",
+			Destination: &Github.AppInstallationID,
+		},
+		&cli.Int64Flag{
+			Name:        "github_app_id",
+			Aliases:     []string{"gaid"},
+			EnvVars:     []string{"GITHUB_APP_ID"},
+			Usage:       "Github App ID",
+			Destination: &Github.AppID,
+		},
+		&cli.StringFlag{
+			Name:        "github_private_key",
+			Aliases:     []string{"gapk"},
+			EnvVars:     []string{"GITHUB_APP_PRIVATE_KEY"},
+			Usage:       "Github App Private Key",
+			Destination: &Github.AppPrivateKey,
 		},
 		&cli.Int64Flag{
 			Name:        "github_refresh",


### PR DESCRIPTION
Adds the ability to specify

GITHUB_APP_INSTALLATION_ID
GITHUB_APP_ID
GITHUB_APP_PRIVATE_KEY

to facilitate authentication using github apps.

- GITHUB_APP_PRIVATE_KEY can be the key itself, or a filename that contains the key.
- gh apps auth is ignored if a private access token is specified

Thanks for this very helpful exporter!




