### PR TITLE
Improve enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If you want to monitor a public repository, you must put the public_repo option 
 | Github Repos | github_repos, grs | GITHUB_REPOS | - | List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test) |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
+| Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |
+| Fields to export | export_fields | EXPORT_FIELDS | repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status | A comma separated list of fields for workflow metrics that should be exported |
 
 ## Exported stats
 
@@ -115,6 +117,25 @@ Gauge type
 | os | Operating system (linux/macos/windows) |
 | orga | Organization name |
 | status | Runner status (online/offline) |
+
+### github_runner_enterprise_status
+Gauge type
+(If you have self hosted runner for an enterprise)
+
+**Result possibility**
+
+| ID | Description |
+|---|---|
+| 0 | Offline |
+| 1 | Online |
+
+**Fields**
+
+| Name | Description |
+|---|---|
+| id | Runner id (incremental id) |
+| name | Runner name |
+| os | Operating system (linux/macos/windows) |
 
 ### github_workflow_usage_seconds
 Gauge type

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,8 +10,10 @@ var (
 		Organizations cli.StringSlice
 		ApiUrl        string
 	}
-	Port  int
-	Debug bool
+	Port           int
+	Debug          bool
+	EnterpriseName string
+	WorkflowFields string
 )
 
 // InitConfiguration - set configuration from env vars or command parameters
@@ -67,6 +69,20 @@ func InitConfiguration() []cli.Flag {
 			EnvVars:     []string{"DEBUG_PROFILE"},
 			Usage:       "Expose pprof information on /debug/pprof/",
 			Destination: &Debug,
+		},
+		&cli.StringFlag{
+			Name:        "enterprise_name",
+			EnvVars:     []string{"ENTERPRISE_NAME"},
+			Usage:       "Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*)",
+			Destination: &EnterpriseName,
+			Value:       "",
+		},
+		&cli.StringFlag{
+			Name:        "export_fields",
+			EnvVars:     []string{"EXPORT_FIELDS"},
+			Usage:       "A comma separated list of fields for workflow metrics that should be exported",
+			Value:       "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status",
+			Destination: &WorkflowFields,
 		},
 	}
 }

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"context"
+	"github-actions-exporter/pkg/config"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	runnersEnterpriseGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_runner_enterprise_status",
+			Help: "runner status",
+		},
+		[]string{"os", "name", "id"},
+	)
+)
+
+func getRunnersEnterpriseFromGithub() {
+	for {
+		runners, _, err := client.Enterprise.ListRunners(context.Background(), config.EnterpriseName, nil)
+		if err != nil {
+			log.Printf("Enterprise.ListRunners error: %s", err.Error())
+		} else {
+			for _, runner := range runners.Runners {
+				var integerStatus float64
+				if integerStatus = 0; runner.GetStatus() == "online" {
+					integerStatus = 1
+				}
+				runnersEnterpriseGauge.WithLabelValues(*runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10)).Set(integerStatus)
+			}
+		}
+		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)
+	}
+}

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -8,32 +8,45 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/google/go-github/v33/github"
 )
 
-var (
-	workflowRunStatusDeprecatedGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "github_job",
-			Help: "Workflow run status, old name and duplicate of github_workflow_run_status that will soon be deprecated",
-		},
-		[]string{"repo", "id", "node_id", "head_branch", "head_sha", "run_number", "workflow_id", "workflow", "event", "status"},
-	)
-	workflowRunStatusGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "github_workflow_run_status",
-			Help: "Workflow run status",
-		},
-		[]string{"repo", "id", "node_id", "head_branch", "head_sha", "run_number", "workflow_id", "workflow", "event", "status"},
-	)
-	workflowRunDurationGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "github_workflow_run_duration_ms",
-			Help: "Workflow run duration (in milliseconds)",
-		},
-		[]string{"repo", "id", "node_id", "head_branch", "head_sha", "run_number", "workflow_id", "workflow", "event", "status"},
-	)
-)
+// getFieldValue return value from run element which corresponds to field
+func getFieldValue(repo string, run github.WorkflowRun, field string) string {
+	switch field {
+	case "repo":
+		return repo
+	case "id":
+		return strconv.FormatInt(*run.ID, 10)
+	case "node_id":
+		return *run.NodeID
+	case "head_branch":
+		return *run.HeadBranch
+	case "head_sha":
+		return *run.HeadSHA
+	case "run_number":
+		return strconv.Itoa(*run.RunNumber)
+	case "workflow_id":
+		return strconv.FormatInt(*run.WorkflowID, 10)
+	case "workflow":
+		return *workflows[repo][*run.WorkflowID].Name
+	case "event":
+		return *run.Event
+	case "status":
+		return *run.Status
+	}
+	return ""
+}
+
+//
+func getRelevantFields(repo string, run *github.WorkflowRun) []string {
+	relevantFields := strings.Split(config.WorkflowFields, ",")
+	result := make([]string, len(relevantFields))
+	for i, field := range relevantFields {
+		result[i] = getFieldValue(repo, *run, field)
+	}
+	return result
+}
 
 // getWorkflowRunsFromGithub - return informations and status about a worflow
 func getWorkflowRunsFromGithub() {
@@ -55,14 +68,19 @@ func getWorkflowRunsFromGithub() {
 					} else if run.GetConclusion() == "queued" {
 						s = 4
 					}
-					workflowRunStatusGauge.WithLabelValues(repo, strconv.FormatInt(*run.ID, 10), *run.NodeID, *run.HeadBranch, *run.HeadSHA, strconv.Itoa(*run.RunNumber), strconv.FormatInt(*run.WorkflowID, 10), *workflows[repo][*run.WorkflowID].Name, *run.Event, *run.Status).Set(s)
-					workflowRunStatusDeprecatedGauge.WithLabelValues(repo, strconv.FormatInt(*run.ID, 10), *run.NodeID, *run.HeadBranch, *run.HeadSHA, strconv.Itoa(*run.RunNumber), strconv.FormatInt(*run.WorkflowID, 10), *workflows[repo][*run.WorkflowID].Name, *run.Event, *run.Status).Set(s)
+
+					fields := getRelevantFields(repo, run)
+
+					workflowRunStatusGauge.WithLabelValues(fields...).Set(s)
 
 					resp, _, err := client.Actions.GetWorkflowRunUsageByID(context.Background(), r[0], r[1], *run.ID)
-					if err != nil {
-						log.Printf("GetWorkflowRunUsageByID error for %s: %s", repo, err.Error())
+					if err != nil { // Fallback for Github Enterprise
+						created := run.CreatedAt.Time.Unix()
+						updated := run.UpdatedAt.Time.Unix()
+						elapsed := updated - created
+						workflowRunDurationGauge.WithLabelValues(fields...).Set(float64(elapsed * 1000))
 					} else {
-						workflowRunDurationGauge.WithLabelValues(repo, strconv.FormatInt(*run.ID, 10), *run.NodeID, *run.HeadBranch, *run.HeadSHA, strconv.Itoa(*run.RunNumber), strconv.FormatInt(*run.WorkflowID, 10), *workflows[repo][*run.WorkflowID].Name, *run.Event, *run.Status).Set(float64(resp.GetRunDurationMS()))
+						workflowRunDurationGauge.WithLabelValues(fields...).Set(float64(resp.GetRunDurationMS()))
 					}
 				}
 			}


### PR DESCRIPTION
This PR introduces 2 new features and one fallback in case timing endpoint is not available (case with Github Enterprise self-hosted runners):
* It exports Github Sefl-Hosted Enterprise runners metrics
* It makes fields that are exported customizable
* Fixes `workflowRunDurationGauge` to work with Slef-Hosted runners