### PR TITLE
Additional fields for runners and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to monitor a public repository, you must put the public_repo option 
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |
-| Fields to export | export_fields | EXPORT_FIELDS | repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status | A comma separated list of fields for workflow metrics that should be exported |
+| Fields to export | export_fields | EXPORT_FIELDS | repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status,created_at,updated_at,conclusion | A comma separated list of fields for workflow metrics that should be exported |
 
 ## Exported stats
 
@@ -49,6 +49,9 @@ Gauge type
 | workflow_id | Workflow ID |
 | workflow | Workflow Name |
 | status | Workflow status (completed/in_progress) |
+| created_at | Workflow run creation timestamp |
+| updated_at | Workflow run update timestamp |
+| conclusion | Result of workflow run |
 
 ### github_workflow_run_duration_ms
 Gauge type
@@ -72,6 +75,10 @@ Gauge type
 | workflow_id | Workflow ID |
 | workflow | Workflow Name |
 | status | Workflow status (completed/in_progress) |
+| created_at | Workflow run creation timestamp |
+| updated_at | Workflow run update timestamp |
+| conclusion | Result of workflow run |
+
 
 ### github_job
 > :warning: **This is a duplicate of the `github_workflow_run_status` metric that will soon be deprecated, do not use anymore.**
@@ -136,6 +143,7 @@ Gauge type
 | id | Runner id (incremental id) |
 | name | Runner name |
 | os | Operating system (linux/macos/windows) |
+| status | Runner status (busy/idle) |
 
 ### github_workflow_usage_seconds
 Gauge type

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github-actions-exporter
 go 1.16
 
 require (
-	github.com/fasthttp/router v1.3.9 // indirect
-	github.com/google/go-github/v33 v33.0.1-0.20210311004518-0540c33dca8b // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/fasthttp/router v1.3.9
+	github.com/google/go-github/v33 v33.0.1-0.20210311004518-0540c33dca8b
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/prometheus/client_golang v1.9.0 // indirect
-	github.com/urfave/cli/v2 v2.3.0 // indirect
-	github.com/valyala/fasthttp v1.22.0 // indirect
-	golang.org/x/oauth2 v0.0.0-20210311163135-5366d9dc1934 // indirect
+	github.com/prometheus/client_golang v1.9.0
+	github.com/urfave/cli/v2 v2.3.0
+	github.com/valyala/fasthttp v1.22.0
+	golang.org/x/oauth2 v0.0.0-20210311163135-5366d9dc1934
 )

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -20,6 +20,7 @@ var (
 )
 
 func getRunnersEnterpriseFromGithub() {
+	runnersEnterpriseGauge.Reset()
 	for {
 		runners, _, err := client.Enterprise.ListRunners(context.Background(), config.EnterpriseName, nil)
 		if err != nil {

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -20,8 +20,8 @@ var (
 )
 
 func getRunnersEnterpriseFromGithub() {
-	runnersEnterpriseGauge.Reset()
 	for {
+		runnersEnterpriseGauge.Reset()
 		runners, _, err := client.Enterprise.ListRunners(context.Background(), config.EnterpriseName, nil)
 		if err != nil {
 			log.Printf("Enterprise.ListRunners error: %s", err.Error())

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -16,7 +16,7 @@ var (
 			Name: "github_runner_enterprise_status",
 			Help: "runner status",
 		},
-		[]string{"os", "name", "id"},
+		[]string{"os", "name", "id", "status"},
 	)
 )
 
@@ -31,7 +31,11 @@ func getRunnersEnterpriseFromGithub() {
 				if integerStatus = 0; runner.GetStatus() == "online" {
 					integerStatus = 1
 				}
-				runnersEnterpriseGauge.WithLabelValues(*runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10)).Set(integerStatus)
+				var status string
+				if status = "idle"; *runner.Busy == true {
+					status = "busy"
+				}
+				runnersEnterpriseGauge.WithLabelValues(*runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10), status).Set(integerStatus)
 			}
 		}
 		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github-actions-exporter/pkg/config"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,7 +15,7 @@ var (
 			Name: "github_runner_enterprise_status",
 			Help: "runner status",
 		},
-		[]string{"os", "name", "id", "status"},
+		[]string{"os", "name", "status"},
 	)
 )
 
@@ -35,7 +34,7 @@ func getRunnersEnterpriseFromGithub() {
 				if status = "idle"; *runner.Busy == true {
 					status = "busy"
 				}
-				runnersEnterpriseGauge.WithLabelValues(*runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10), status).Set(integerStatus)
+				runnersEnterpriseGauge.WithLabelValues(*runner.OS, *runner.Name, status).Set(integerStatus)
 			}
 		}
 		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -34,6 +34,12 @@ func getFieldValue(repo string, run github.WorkflowRun, field string) string {
 		return *run.Event
 	case "status":
 		return *run.Status
+	case "conclusion":
+		return run.GetConclusion()
+	case "created_at":
+		return run.CreatedAt.Format(time.RFC3339)
+	case "updated_at":
+		return run.UpdatedAt.Format(time.RFC3339)
 	}
 	return ""
 }


### PR DESCRIPTION
This PR adds possibility to expose additional metric for
* Workflow
  *  `created_at` - Time workflow was create
  *  `updated_at` - Time workflow was modified
  *  `conclusion` - In addition to status indicates if workflow succeeded or failed
* Enterprise runners
  * `status` - Indicates if runner is currently busy or idle
 
Additionally `id` field was removed from `github_runner_enterprise_status` as it is irrelevant for metrics