### PR TITLE
workflow to publish helm chart

### DIFF
--- a/.github/workflows/chart_release.yml
+++ b/.github/workflows/chart_release.yml
@@ -1,0 +1,19 @@
+name: Release Chart
+on:
+  push:
+    branches:
+      - master
+    paths: 
+      - "deploy/helm-chart/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          charts_dir: deploy/helm-chart
+          linting: off
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ github-actions-exporter for prometheus
 
 Container image : https://hub.docker.com/repository/docker/spendeskplatform/github-actions-exporter
 
+Helm Chart :
+```
+ helm chart repo: https://Spendesk.github.io/github-actions-exporter/
+ chart: github-actions-exporter
+ version: "0.1.4"
+```
+
 ## Information
 If you want to monitor a public repository, you must put the public_repo option in the repo scope of your github token or Github App Authentication.
 


### PR DESCRIPTION
i added a workflow to publish helm chart. 

you need to delete the current gh-pages branch 
then create an empty gh-pages branch 
as per https://www.gep13.co.uk/blog/how-to-create-gh-pages-branch

git checkout --orphan gh-pages
git rm -rf .
echo "gh-pages for helm charts" > index.html
git add index.html
git commit -a -m "gh-pages"
git push --set-upstream origin gh-pages

then any change to chart like version number will create chart in gh-pages. 
Then i can start using your chart.   -) 

```
 helm chart repo: https://Spendesk.github.io/github-actions-exporter/
 chart: github-actions-exporter
 version: "0.1.4"
```