### PR TITLE
Add break to prevent log flooding and API abuse

### DIFF
--- a/pkg/metrics/get_runners_organization_from_github.go
+++ b/pkg/metrics/get_runners_organization_from_github.go
@@ -30,6 +30,7 @@ func getRunnersOrganizationFromGithub() {
 				resp, rr, err := client.Actions.ListOrganizationRunners(context.Background(), orga, opt)
 				if err != nil {
 					log.Printf("ListOrganizationRunners error for %s: %s", orga, err.Error())
+					break
 				} else {
 					for _, runner := range resp.Runners {
 						if runner.GetStatus() == "online" {


### PR DESCRIPTION
When running into connectivity or authentication problems, getRunnersOrganizationFromGithub gets stucked in a loop flooding the stdout with logs and hitting non-stop the Github API.
With a break, if it runs into an error of any sort, it will continue with the next org. If errors occurs with next orgs, it will only fail once and finally after checking all orgs it will pause the specified refresh value.