### PR TITLE
fix: github_runner_status

### DIFF
--- a/pkg/metrics/get_runners_from_github.go
+++ b/pkg/metrics/get_runners_from_github.go
@@ -30,6 +30,8 @@ func getRunnersFromGithub() {
 			if err != nil {
 				log.Printf("ListRunners error for %s: %s", repo, err.Error())
 			} else {
+				runnersGauge.Reset()
+
 				for _, runner := range resp.Runners {
 					if runner.GetStatus() == "online" {
 						runnersGauge.WithLabelValues(repo, *runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10), strconv.FormatBool(runner.GetBusy())).Set(1)

--- a/pkg/metrics/get_runners_organization_from_github.go
+++ b/pkg/metrics/get_runners_organization_from_github.go
@@ -31,6 +31,8 @@ func getRunnersOrganizationFromGithub() {
 				if err != nil {
 					log.Printf("ListOrganizationRunners error for %s: %s", orga, err.Error())
 				} else {
+					runnersGauge.Reset()
+
 					for _, runner := range resp.Runners {
 						if runner.GetStatus() == "online" {
 							runnersOrganizationGauge.WithLabelValues(orga, *runner.OS, *runner.Name, strconv.FormatInt(runner.GetID(), 10), strconv.FormatBool(runner.GetBusy())).Set(1)


### PR DESCRIPTION
The busy label creates metrics duplicates with the wrong status.
We need to reset runner status before fill it.