### PR TITLE
feat: moving GITHUB_REPOS to read from a txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Authentication can either via a Github Token or the Github App Authentication 3 
 | Github App Private Key | app_private_key, gpk | GITHUB_APP_PRIVATE_KEY | - | Github App Authentication Private Key |
 | Github Refresh | github_refresh, gr | GITHUB_REFRESH | 30 | Refresh time Github Actions status in sec |
 | Github Organizations | github_orgas, go | GITHUB_ORGAS | - | List all organizations you want get informations. Format \<orga1>,\<orga2>,\<orga3> (like test1,test2) |
-| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
+| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Multiline format, check `example_repo.txt`. Defaults to all repositories owned by the organizations. |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Gauge type
 | 2 | Skipped |
 | 3 | In Progress |
 | 4 | Queued |
+| 5 | Cancelled |
 
 **Fields**
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Authentication can either via a Github Token or the Github App Authentication 3 
 | Github App Private Key | app_private_key, gpk | GITHUB_APP_PRIVATE_KEY | - | Github App Authentication Private Key |
 | Github Refresh | github_refresh, gr | GITHUB_REFRESH | 30 | Refresh time Github Actions status in sec |
 | Github Organizations | github_orgas, go | GITHUB_ORGAS | - | List all organizations you want get informations. Format \<orga1>,\<orga2>,\<orga3> (like test1,test2) |
-| Github Repos | github_repos, grs | GITHUB_REPOS | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
+| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |

--- a/example_repo.txt
+++ b/example_repo.txt
@@ -1,0 +1,2 @@
+org-name/repo-name-1
+org-name/repo-name-2

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var (
 	Debug          bool
 	EnterpriseName string
 	WorkflowFields string
+	RepoFilePath   string
 )
 
 // InitConfiguration - set configuration from env vars or command parameters
@@ -86,13 +87,6 @@ func InitConfiguration() []cli.Flag {
 			Usage:       "List all organizations you want get informations. Format <orga>,<orga2>,<orga3> (like test,test2)",
 			Destination: &Github.Organizations,
 		},
-		&cli.StringSliceFlag{
-			Name:        "github_repos",
-			Aliases:     []string{"grs"},
-			EnvVars:     []string{"GITHUB_REPOS"},
-			Usage:       "List all repositories you want get informations. Format <orga>/<repo>,<orga>/<repo2>,<orga>/<repo3> (like test/test)",
-			Destination: &Github.Repositories,
-		},
 		&cli.BoolFlag{
 			Name:        "debug_profile",
 			EnvVars:     []string{"DEBUG_PROFILE"},
@@ -126,6 +120,12 @@ func InitConfiguration() []cli.Flag {
 			Value:       100 * 1024 * 1024,
 			Usage:       "Size of Github HTTP cache in bytes",
 			Destination: &Github.CacheSizeBytes,
+		},
+		&cli.StringFlag{
+			Name:        "repo_list_file",
+			Usage:       "Path to the repo list file",
+			EnvVars:     []string{"REPO_LIST_FILE"},
+			Destination: &RepoFilePath,
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func InitConfiguration() []cli.Flag {
 			Name:        "export_fields",
 			EnvVars:     []string{"EXPORT_FIELDS"},
 			Usage:       "A comma separated list of fields for workflow metrics that should be exported",
-			Value:       "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status",
+			Value:       "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status,conclusion",
 			Destination: &WorkflowFields,
 		},
 		&cli.BoolFlag{

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -60,12 +60,12 @@ func getRelevantFields(repo string, run *github.WorkflowRun) []string {
 }
 
 func getRecentWorkflowRuns(owner string, repo string) []*github.WorkflowRun {
-	window_start := time.Now().Add(time.Duration(-12) * time.Hour).Format(time.RFC3339)
+	window_start := time.Now().Add(time.Duration(-1) * time.Minute).Format(time.RFC3339)
 	opt := &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 200},
 		Created:     ">=" + window_start,
 	}
-
+	log.Printf("getRecentWorkflowRuns for %s", repo)
 	var runs []*github.WorkflowRun
 	for {
 		resp, rr, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), owner, repo, opt)

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -62,7 +62,7 @@ func getRelevantFields(repo string, run *github.WorkflowRun) []string {
 }
 
 func getRecentWorkflowRuns(owner string, repo string) []*github.WorkflowRun {
-	window_start := time.Now().Add(time.Duration(-1) * time.Minute).Format(time.RFC3339)
+	window_start := time.Now().Add(time.Duration(-12) * time.Hour).Format(time.RFC3339)
 	opt := &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 200},
 		Created:     ">=" + window_start,

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -62,7 +62,7 @@ func getRelevantFields(repo string, run *github.WorkflowRun) []string {
 }
 
 func getRecentWorkflowRuns(owner string, repo string) []*github.WorkflowRun {
-	window_start := time.Now().Add(time.Duration(-12) * time.Hour).Format(time.RFC3339)
+	window_start := time.Now().Add(time.Duration(-1) * time.Minute).Format(time.RFC3339)
 	opt := &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 200},
 		Created:     ">=" + window_start,

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -60,12 +60,12 @@ func getRelevantFields(repo string, run *github.WorkflowRun) []string {
 }
 
 func getRecentWorkflowRuns(owner string, repo string) []*github.WorkflowRun {
-	window_start := time.Now().Add(time.Duration(-1) * time.Minute).Format(time.RFC3339)
+	window_start := time.Now().Add(time.Duration(-12) * time.Hour).Format(time.RFC3339)
 	opt := &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 200},
 		Created:     ">=" + window_start,
 	}
-	log.Printf("getRecentWorkflowRuns for %s", repo)
+
 	var runs []*github.WorkflowRun
 	for {
 		resp, rr, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), owner, repo, opt)

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -106,6 +106,8 @@ func getRunUsage(owner string, repo string, runId int64) *github.WorkflowRunUsag
 // getWorkflowRunsFromGithub - return informations and status about a workflow
 func getWorkflowRunsFromGithub() {
 	for {
+		log.Println("Reset workflowRunStatusGauge")
+		workflowRunStatusGauge.Reset()
 		for _, repo := range repositories {
 			r := strings.Split(repo, "/")
 			runs := getRecentWorkflowRuns(r[0], r[1])

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -45,6 +45,8 @@ func getFieldValue(repo string, run github.WorkflowRun, field string) string {
 		return *run.Event
 	case "status":
 		return *run.Status
+	case "conclusion":
+		return run.GetConclusion()
 	}
 	log.Printf("Tried to fetch invalid field '%s'", field)
 	return ""
@@ -106,8 +108,6 @@ func getRunUsage(owner string, repo string, runId int64) *github.WorkflowRunUsag
 // getWorkflowRunsFromGithub - return informations and status about a workflow
 func getWorkflowRunsFromGithub() {
 	for {
-		log.Println("Reset workflowRunStatusGauge")
-		workflowRunStatusGauge.Reset()
 		for _, repo := range repositories {
 			r := strings.Split(repo, "/")
 			runs := getRecentWorkflowRuns(r[0], r[1])
@@ -122,6 +122,8 @@ func getWorkflowRunsFromGithub() {
 					s = 3
 				} else if run.GetConclusion() == "queued" {
 					s = 4
+				} else if run.GetConclusion() == "cancelled" {
+					s = 5
 				}
 
 				fields := getRelevantFields(repo, run)

--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -100,6 +100,10 @@ func periodicGithubFetcher() {
 		ww := make(map[string]map[int64]github.Workflow)
 		for _, repo := range repos_to_fetch {
 			r := strings.Split(repo, "/")
+			if len(r) != 2 {
+				log.Printf("Skipping invalid repository %s", repo)
+				continue
+			}
 			workflows_for_repo := getAllWorkflowsForRepo(r[0], r[1])
 			if len(workflows_for_repo) == 0 {
 				continue

--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -81,8 +82,12 @@ func periodicGithubFetcher() {
 
 		// Fetch repositories (if dynamic)
 		var repos_to_fetch []string
-		if len(config.Github.Repositories.Value()) > 0 {
-			repos_to_fetch = config.Github.Repositories.Value()
+		if len(config.RepoFilePath) > 0 {
+			data, err := os.ReadFile(config.RepoFilePath)
+			if err != nil {
+				log.Fatalf("error reading file %s", err)
+			}
+			repos_to_fetch = strings.Split(string(data), "\n")
 		} else {
 			for _, orga := range config.Github.Organizations.Value() {
 				repos_to_fetch = append(repos_to_fetch, getAllReposForOrg(orga)...)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,6 +27,7 @@ var (
 
 // InitMetrics - register metrics in prometheus lib and start func for monitor
 func InitMetrics() {
+	log.Println("Init metric")
 	workflowRunStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "github_workflow_run_status",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,14 +31,14 @@ func InitMetrics() {
 	workflowRunStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "github_workflow_run_status",
-			Help: "Workflow run status of all workflow runs created in the last 12hr",
+			Help: "Workflow run status of all workflow runs created in the last 1 minute",
 		},
 		strings.Split(config.WorkflowFields, ","),
 	)
 	workflowRunDurationGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "github_workflow_run_duration_ms",
-			Help: "Workflow run duration (in milliseconds) of all workflow runs created in the last 12hr",
+			Help: "Workflow run duration (in milliseconds) of all workflow runs created in the last 1 minute",
 		},
 		strings.Split(config.WorkflowFields, ","),
 	)


### PR DESCRIPTION
Listing many repositories as a long, comma-separated string can sometimes be inconvenient and difficult to read. 
Therefore, I've created a new flag named 'repo_list_file' or an environment variable 'REPO_LIST_FILE'.  This reads a multiline text file containing a list of repositories. 
An example of this file can be found in 'example_repo.txt'.